### PR TITLE
人脸识别接口调用

### DIFF
--- a/miniprogram/pages/orderPages/facialRecognition/facialRecognition.js
+++ b/miniprogram/pages/orderPages/facialRecognition/facialRecognition.js
@@ -85,7 +85,7 @@ Page({
       title: '识别中',
     })
     this.ctx.takePhoto({
-      quality: 'high',
+      quality: 'normal',
       success: (res_photo) => {
         //console.log('临时url:', res_photo.tempImagePath, typeof(res_photo.tempImagePath))
         //console.log('改后url:', wx.getFileSystemManager().readFileSync(res_photo.tempImagePath, 'base64'), typeof(wx.getFileSystemManager().readFileSync(res_photo.tempImagePath, 'base64')))


### PR DESCRIPTION
降低成像质量。成像质量太大容易调用失败